### PR TITLE
Exposing more utilities so that users can interact with a PerspectiveProxyRayServer

### DIFF
--- a/raydar/dashboard/server.py
+++ b/raydar/dashboard/server.py
@@ -51,9 +51,6 @@ class PerspectiveRayServer:
         if tablename in self._tables:
             self._tables[tablename].clear()
 
-    def get_table(self, tablename: str) -> None:
-        return self._schemas.get(tablename, None)
-
     @app.get("/")
     async def site(self):
         return FileResponse(join(static_files_dir, "index.html"))

--- a/raydar/task_tracker/__init__.py
+++ b/raydar/task_tracker/__init__.py
@@ -1,1 +1,1 @@
-from .task_tracker import AsyncMetadataTracker, RayTaskTracker
+from .task_tracker import *

--- a/raydar/tests/conftest.py
+++ b/raydar/tests/conftest.py
@@ -35,7 +35,6 @@ def unittest_ray_config():
     config = dict(
         num_cpus=5,
         include_dashboard=True,
-        dashboard_host="0.0.0.0",
     )
     return config
 


### PR DESCRIPTION
Moved from #19 

<img width="1251" alt="image" src="https://github.com/Point72/raydar/assets/16946312/ac1ebb2a-952f-4550-aa50-9bfddd4b2c74">

So this is truly just an RFC, but some conversations around further emphasizing a the perspective component of things without requiring a RayTaskTracker object were happening, and this diff is up to facilitate those discussions.