### PR TITLE
Removing trailing slashes in websocket/tables route where applicable

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -7,17 +7,25 @@ import "@finos/perspective-viewer/dist/css/themes.css";
 import "@finos/perspective-workspace";
 import "./index.css";
 
+function removeTrailingSlash(url) {
+  return url.replace(/\/$/, "");
+}
+
 window.addEventListener("load", async () => {
   const workspace = document.querySelector("perspective-workspace");
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
   const websocket = perspective.websocket(
-    `${protocol}//${window.location.host}${window.location.pathname}/ws`,
+    `${protocol}//${window.location.host}${removeTrailingSlash(
+      window.location.pathname,
+    )}/ws`,
   );
   const registeredTables = new Set();
   const worker = perspective.worker();
 
   const updateTables = async () => {
-    const response = await fetch(`${window.location.href}/tables`);
+    const response = await fetch(
+      `${removeTrailingSlash(window.location.href)}/tables`,
+    );
     const tables = await response.json();
 
     tables.map(async (tableName) => {

--- a/raydar/task_tracker/task_tracker.py
+++ b/raydar/task_tracker/task_tracker.py
@@ -9,7 +9,7 @@ import ray
 from collections.abc import Iterable
 from packaging.version import Version
 from ray.serve import shutdown
-from typing import Optional
+from typing import Dict, List, Optional
 
 from .schema import schema as default_schema
 
@@ -351,6 +351,16 @@ class RayTaskTracker:
     def clear(self) -> None:
         """Clear the dataframe used by this object's AsyncMetadataTracker actor"""
         return ray.get(self.tracker.clear_df.remote())
+
+    def create_table(self, table_name: str, table_schema: Dict[str, str]) -> None:
+        """Create a new perspective table using the proxy server used by the RayTaskTracker's AsyncMetadataTracker actor"""
+        proxy_server = self.proxy_server()
+        return ray.get(proxy_server.remote("new", table_name, table_schema))
+
+    def update_table(self, table_name: str, data: List[Dict]) -> None:
+        """Update rows of perspective table held by the proxy server used by the RayTaskTracker's AsyncMetadataTracker actor"""
+        proxy_server = self.proxy_server()
+        return ray.get(proxy_server.remote("update", table_name, data))
 
     def proxy_server(self) -> ray.serve.handle.DeploymentHandle:
         """Fetch the proxy server used by this object's AsyncMetadataTracker actor"""


### PR DESCRIPTION
<img width="935" alt="image" src="https://github.com/user-attachments/assets/1517eb8a-1b5b-4add-932f-3ca119cc4ff2">

so, looks like the default host/location when launching raydar locally might causes some 404s because we're double-including a `/` character. 

I trim the character where applicable now, but still let us use the 

```
ray.serve.start(http_options=ray.serve.config.HTTPOptions(host="0.0.0.0"))
```
options required for other applications