### PR TITLE
Adding option to create/update arbitrary perspective tables

### DIFF
--- a/raydar/task_tracker/task_tracker.py
+++ b/raydar/task_tracker/task_tracker.py
@@ -9,7 +9,7 @@ import ray
 from collections.abc import Iterable
 from packaging.version import Version
 from ray.serve import shutdown
-from typing import Optional
+from typing import Dict, List, Optional
 
 from .schema import schema as default_schema
 
@@ -351,6 +351,16 @@ class RayTaskTracker:
     def clear(self) -> None:
         """Clear the dataframe used by this object's AsyncMetadataTracker actor"""
         return ray.get(self.tracker.clear_df.remote())
+
+    def create_table(self, table_name: str, table_schema: Dict[str, str]) -> None:
+        """Create a new perspective table using the proxy server used by the RayTaskTracker's AsyncMetadataTracker actor"""
+        proxy_server = self.proxy_server()
+        return ray.get(proxy_server.remote("new", table_name, table_schema))
+
+    def update_table(self, table_name: str, data: List[Dict]) -> None:
+        """Update rows of perspective table held by the proxy server used by the RayTaskTracker's AsyncMetadataTracker actor"""
+        proxy_server = self.proxy_server()
+        return ray.get(proxy_server.remote("update", table_name, data))
 
     def proxy_server(self) -> ray.serve.handle.DeploymentHandle:
         """Fetch the proxy server used by this object's AsyncMetadataTracker actor"""


### PR DESCRIPTION
previously, the guidance has been this:

```
task_tracker = RayTaskTracker(enable_perspective_dashboard=True)
proxy_server = task_tracker.proxy_server()
proxy_server.remote(
    "new",
    "metrics_table",
    {
        "node_id": "str",
        "metric_name": "str",
        "value": "float",
        "timestamp": "datetime",
    },
)
```
then somewhere in your code, do this:
```
def my_model_training_loop()

	for epoch in range(num_epochs):

    # ... my training code here ...

		data = dict(
			node_id=ray.get_runtime_context().get_node_id(),
			metric_name="loss",
			value=loss.item(),
			timestamp=time.time(),
		)
		proxy_server.remote("update", "metrics_table", [data])
```

but this is a little clunky, and probably could be obfuscated behind some cleaner wrappers. So the proposal here is to instead: 

```
task_tracker = RayTaskTracker(enable_perspective_dashboard=True)
task_tracker.create_table(
    "metrics_table",
    {
        "node_id": "str",
        "metric_name": "str",
        "value": "float",
        "timestamp": "datetime",
    },
)
```

and then 
```
def my_model_training_loop()

	for epoch in range(num_epochs):

    # ... my training code here ...

		data = dict(
			node_id=ray.get_runtime_context().get_node_id(),
			metric_name="loss",
			value=loss.item(),
			timestamp=time.time(),
		)
		task_tracker.update_table("metrics_table", [data])
```