### PR TITLE
Offer easier function to save/store layout options from the workspace

### DIFF
--- a/raydar/dashboard/server.py
+++ b/raydar/dashboard/server.py
@@ -1,3 +1,5 @@
+import json
+import os
 from fastapi import FastAPI, HTTPException, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -106,6 +108,16 @@ class PerspectiveRayServer:
             self.update(tablename, data)
         except BaseException as exception:
             raise HTTPException(503, f"Exception during data ingestion: {tablename} / {format_exc()}") from exception
+
+    @app.post("/save_workspace_layout")
+    async def save_workspace_layout(self, layout: dict) -> Response:
+        file_path = os.path.join(static_files_dir, "layouts", "default.json")
+        try:
+            with open(file_path, "w") as f:
+                json.dump(layout, f, indent=2)
+            return Response(status_code=200)
+        except Exception as e:
+            raise HTTPException(502, f"Exception thrown when saving layout!: {str(e)}")
 
     def update(self, tablename: str, data):
         if isinstance(data, dict):


### PR DESCRIPTION
```
let workspace = document.querySelector('perspective-workspace');

workspace.save().then(config => {
    // Convert the configuration object to a JSON string
    let json = JSON.stringify(config);

    // Send the JSON string to the server
    fetch('/save_workspace_layout', {
        method: 'POST',
        headers: {
            'Content-Type': 'application/json',
        },
        body: json  // Send the JSON string directly
    })
    .then(response => response.json())
    .then(data => {
        console.log('Success:', data);
    })
    .catch((error) => {
        console.error('Error:', error);
    });
});
```

doing this within the console now overwrites the default.json layout. would be cool if we could just add a button to the default raydar UI that does that for us. 